### PR TITLE
Adding Application Insights and API Key security

### DIFF
--- a/Keras_Tensorflow/02_BuildImage.ipynb
+++ b/Keras_Tensorflow/02_BuildImage.ipynb
@@ -18,7 +18,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -65,7 +67,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "os.makedirs('flaskwebapp', exist_ok=True)\n",
@@ -99,7 +103,136 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below, we create the module for the Flask web application."
+    "The use of Azure Application Insights can provide information about your service with very little work on the developers behalf.  \n",
+    "\n",
+    "To make use of Azure Application Insights. Simply follow the instructions in the code block below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile flaskwebapp/applicationinsights.py\n",
+    "from app import app\n",
+    "\n",
+    "####\n",
+    "# Azure Application Insights\n",
+    "#\n",
+    "# Application Insights can be very useful in collecting metrics about your endpoint. Instrumenting your service\n",
+    "# with Application Insights requires very little work on your part as a developer. \n",
+    "#\n",
+    "#   Step 1: Install the applicationinsights package\n",
+    "#       pip install applicationinsights\n",
+    "#   Step 2: Create an Application Inisights service on your Azure Subscription (see the post linked below)\n",
+    "#       https://blogs.msdn.microsoft.com/najib/2018/05/11/monitoring-python-applications-with-azure-app-insights/\n",
+    "#   Step 3: Collect the instrumentation key from Azure Portal (as noted in the blog) and replace the text noted by \n",
+    "#       <YOUR INSTRUMENTATION KEY GOES HERE> it in the commented code block below\n",
+    "#   Step 4: Uncomment the code lines below\n",
+    "#### \n",
+    "#from applicationinsights.flask.ext import AppInsights\n",
+    "#app.config['APPINSIGHTS_INSTRUMENTATIONKEY'] = '<YOUR INSTRUMENTATION KEY GOES HERE>'\n",
+    "#appinsights = AppInsights(app)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exposing open endpoints on the internet can be dangerous. The following code block is used to provide an API Key security measure to the endpoint that will be exposed. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile flaskwebapp/apisecurity.py\n",
+    "from flask import request,abort\n",
+    "from functools import wraps\n",
+    "from werkzeug.exceptions import HTTPException\n",
+    "\n",
+    "#####################################################################\n",
+    "# API KEY Security\n",
+    "#####################################################################\n",
+    "# Protecting your API is a critical component of any service. The\n",
+    "# service shown in this example is manually created and to keep it\n",
+    "# as simple as possible, a mock API Key is used to protect the end-\n",
+    "# point. \n",
+    "# \n",
+    "# When using Azure ML SDK or other commercial services, a key is \n",
+    "# provided for your endpoint. The following code is used to wrap\n",
+    "# the endpoint to validate an API Key. This code is not secure and\n",
+    "# the reader should determine the best way to protect thier own \n",
+    "# endpoints.\n",
+    "# \n",
+    "# On a POST action to the endpoint, provide the Authorization \n",
+    "# header :\n",
+    "# {\n",
+    "#   \"Authorization\" : \"Bearer [YOUR_API_KEY]\"   \n",
+    "# } \n",
+    "# \n",
+    "# The function below will verify that:\n",
+    "#   1. The Authorization header exists\n",
+    "#       If not present return 401\n",
+    "#   2. The content of that header contains \"Bearer KEY\"\n",
+    "#       If not present return 401\n",
+    "#   3. The KEY provided matches YOUR_API_KEY\n",
+    "#       If not a match return 403\n",
+    "#\n",
+    "# Usage:\n",
+    "#\n",
+    "# @require_appkey\n",
+    "# def routefunction():\n",
+    "\n",
+    "YOUR_API_KEY = \"4191d34b28ed4885a1ea0b141e0794ef\"\n",
+    "def require_appkey(view_function):\n",
+    "    @wraps(view_function)\n",
+    "    # the new, post-decoration function. Note *args and **kwargs here.\n",
+    "    def decorated_function(*args, **kwargs):\n",
+    "        key = None\n",
+    "        keytype = None\n",
+    "\n",
+    "        # Ensure Authorization header is present, and the content is 2 words 'Bearer [key]'\n",
+    "        # collect both and check it's Bearer before saving the key.\n",
+    "        if 'Authorization' in request.headers:\n",
+    "            payload = request.headers.get('Authorization').split()      \n",
+    "            if len(payload) == 2:\n",
+    "                keyType = payload[0]\n",
+    "                if keyType == 'Bearer':\n",
+    "                    key = payload[1]\n",
+    "\n",
+    "        # If there is no key send 401 (unauthorized), otherwise if the key is wrong\n",
+    "        # send a 403 (forbidden)\n",
+    "        if key:\n",
+    "            if key == YOUR_API_KEY:\n",
+    "                return view_function(*args, **kwargs)\n",
+    "            else:\n",
+    "                try:\n",
+    "                    abort(401)\n",
+    "                except HTTPException as e:\n",
+    "                    return e\n",
+    "        else:\n",
+    "            try:\n",
+    "                abort(403)\n",
+    "            except HTTPException as e:\n",
+    "                return e\n",
+    "    return decorated_function\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we create the module for the Flask web application.\n",
+    "\n",
+    "Note that we include the Azure Application Insights and Api Security files below. The API Security is applied only to the scoring endpoint and the Azure Application Insights is not currently utilized. "
    ]
   },
   {
@@ -122,11 +255,14 @@
     "import logging\n",
     "import json\n",
     "import driver\n",
+    "from .apisecurity import require_appkey\n",
+    "from .applicationinsights import *\n",
     "\n",
     "app = Flask(__name__)\n",
     "predict_for = driver.get_model_api()\n",
     " \n",
     "@app.route(\"/score\", methods = ['POST'])\n",
+    "@require_appkey\n",
     "def scoreRRS():\n",
     "    \"\"\" Endpoint for scoring\n",
     "    \"\"\"\n",
@@ -451,7 +587,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%dotenv\n",
@@ -470,7 +608,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "!docker build -t $image_name -f $docker_file_location $application_path --no-cache"
@@ -510,13 +650,7 @@
       "\u001b[1Bdd00b1a4: Preparing \n",
       "\u001b[1Bc3c04cbd: Preparing \n",
       "\u001b[1Bdaf493f1: Preparing \n",
-      "\u001b[1B88d0e278: Preparing \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\u001b[1B88d0e278: Preparing \n",
       "\u001b[17Bf9bf5d6: Pushing  999.4MB/2.059GBet-gpu 1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[13A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[13A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[15A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[12A\u001b[1K\u001b[K\u001b[12A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[11A\u001b[1K\u001b[K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[10A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[16A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[7A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[9A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[KPushing  330.4MB/2.059GB\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[8A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[4A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[3A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[5A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[KPushing  654.3MB/2.059GB\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[KPushing  1.027GB/1.263GB\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17Bf9bf5d6: Pushed   2.137GB/2.059GB\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[18A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[KPushing  1.963GB/2.059GB\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[K\u001b[17A\u001b[1K\u001b[Klatest: digest: sha256:029335f63f0f52e21f6ad2e5efbf966e1b47c36eaf90812b5fc646667d1779bb size: 4090\n"
      ]
     }
@@ -552,9 +686,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeploymentKeras]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeploymentKeras-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -566,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Keras_Tensorflow/03_TestLocally.ipynb
+++ b/Keras_Tensorflow/03_TestLocally.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -64,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%bash --bg -s \"$image_name\"\n",
@@ -122,7 +126,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "IMAGEURL = \"https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg\""
@@ -205,7 +211,7 @@
     }
    ],
    "source": [
-    "headers = {'content-type': 'application/json'}\n",
+    "headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}\n",
     "%time r = requests.post('http://0.0.0.0:80/score', data=jsonimg, headers=headers)\n",
     "print(r)\n",
     "r.json()"
@@ -221,7 +227,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "images = ('https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg',\n",
@@ -235,7 +243,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "url = 'http://0.0.0.0:80/score'\n",
@@ -280,7 +290,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image_data = list(map(img_url_to_json, images)) # Retrieve the images and data"
@@ -289,7 +301,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "timer_results = list()\n",
@@ -368,9 +382,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeploymentKeras]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeploymentKeras-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -382,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Keras_Tensorflow/05_TestWebApp.ipynb
+++ b/Keras_Tensorflow/05_TestWebApp.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -38,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "service_json = !kubectl get service azure-dl -o json\n",
@@ -56,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "scoring_url = 'http://{}/score'.format(app_url)\n",
@@ -108,7 +114,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "IMAGEURL = \"https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg\""
@@ -171,7 +179,7 @@
    ],
    "source": [
     "jsonimg = img_url_to_json(IMAGEURL)\n",
-    "headers = {'content-type': 'application/json'}\n",
+    "headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}\n",
     "r = requests.post(scoring_url, data=jsonimg, headers=headers) # Run the request twice since the first time takes a \n",
     "%time r = requests.post(scoring_url, data=jsonimg, headers=headers) # little longer due to the loading of the model\n",
     "print(r)\n",
@@ -195,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "images = ('https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg',\n",
@@ -209,7 +219,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "results = [requests.post(scoring_url, data=img_url_to_json(img), headers=headers) for img in images]"
@@ -260,7 +272,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image_data = list(map(img_url_to_json, images)) # Retrieve the images and data"
@@ -269,7 +283,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "timer_results = list()\n",
@@ -330,9 +346,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeploymentKeras]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeploymentKeras-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -344,7 +360,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Keras_Tensorflow/06_SpeedTestWebApp.ipynb
+++ b/Keras_Tensorflow/06_SpeedTestWebApp.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import asyncio\n",
@@ -61,7 +63,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "NUMBER_OF_REQUESTS = 100  # Total number of requests\n",
@@ -78,7 +82,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "service_json = !kubectl get service azure-dl -o json\n",
@@ -89,7 +95,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "scoring_url = 'http://{}/score'.format(app_url)\n",
@@ -154,7 +162,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "url_list = [[scoring_url, jsonimg] for jsonimg in gen_variations_of_one_image(IMAGEURL, NUMBER_OF_REQUESTS)]"
@@ -163,7 +173,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def decode(result):\n",
@@ -173,7 +185,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def fetch(url, session, data, headers):\n",
@@ -187,7 +201,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def bound_fetch(sem, url, session, data, headers):\n",
@@ -199,7 +215,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def await_with_progress(coros):\n",
@@ -213,11 +231,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def run(url_list, num_concurrent=CONCURRENT_REQUESTS):\n",
-    "    headers = {'content-type': 'application/json'}\n",
+    "    headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}\n",
     "    tasks = []\n",
     "    # create instance of Semaphore\n",
     "    sem = asyncio.Semaphore(num_concurrent)\n",
@@ -362,9 +382,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeploymentKeras]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeploymentKeras-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -376,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Tensorflow/02_BuildImage.ipynb
+++ b/Tensorflow/02_BuildImage.ipynb
@@ -11,7 +11,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -58,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "os.makedirs('flaskwebapp', exist_ok=True)\n",
@@ -93,7 +97,136 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is the module for the Flask web application."
+    "The use of Azure Application Insights can provide information about your service with very little work on the developers behalf.  \n",
+    "\n",
+    "To make use of Azure Application Insights. Simply follow the instructions in the code block below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile flaskwebapp/applicationinsights.py\n",
+    "from app import app\n",
+    "\n",
+    "####\n",
+    "# Azure Application Insights\n",
+    "#\n",
+    "# Application Insights can be very useful in collecting metrics about your endpoint. Instrumenting your service\n",
+    "# with Application Insights requires very little work on your part as a developer. \n",
+    "#\n",
+    "#   Step 1: Install the applicationinsights package\n",
+    "#       pip install applicationinsights\n",
+    "#   Step 2: Create an Application Inisights service on your Azure Subscription (see the post linked below)\n",
+    "#       https://blogs.msdn.microsoft.com/najib/2018/05/11/monitoring-python-applications-with-azure-app-insights/\n",
+    "#   Step 3: Collect the instrumentation key from Azure Portal (as noted in the blog) and replace the text noted by \n",
+    "#       <YOUR INSTRUMENTATION KEY GOES HERE> it in the commented code block below\n",
+    "#   Step 4: Uncomment the code lines below\n",
+    "#### \n",
+    "#from applicationinsights.flask.ext import AppInsights\n",
+    "#app.config['APPINSIGHTS_INSTRUMENTATIONKEY'] = '<YOUR INSTRUMENTATION KEY GOES HERE>'\n",
+    "#appinsights = AppInsights(app)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exposing open endpoints on the internet can be dangerous. The following code block is used to provide an API Key security measure to the endpoint that will be exposed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile flaskwebapp/apisecurity.py\n",
+    "from flask import request,abort\n",
+    "from functools import wraps\n",
+    "from werkzeug.exceptions import HTTPException\n",
+    "\n",
+    "#####################################################################\n",
+    "# API KEY Security\n",
+    "#####################################################################\n",
+    "# Protecting your API is a critical component of any service. The\n",
+    "# service shown in this example is manually created and to keep it\n",
+    "# as simple as possible, a mock API Key is used to protect the end-\n",
+    "# point. \n",
+    "# \n",
+    "# When using Azure ML SDK or other commercial services, a key is \n",
+    "# provided for your endpoint. The following code is used to wrap\n",
+    "# the endpoint to validate an API Key. This code is not secure and\n",
+    "# the reader should determine the best way to protect thier own \n",
+    "# endpoints.\n",
+    "# \n",
+    "# On a POST action to the endpoint, provide the Authorization \n",
+    "# header :\n",
+    "# {\n",
+    "#   \"Authorization\" : \"Bearer [YOUR_API_KEY]\"   \n",
+    "# } \n",
+    "# \n",
+    "# The function below will verify that:\n",
+    "#   1. The Authorization header exists\n",
+    "#       If not present return 401\n",
+    "#   2. The content of that header contains \"Bearer KEY\"\n",
+    "#       If not present return 401\n",
+    "#   3. The KEY provided matches YOUR_API_KEY\n",
+    "#       If not a match return 403\n",
+    "#\n",
+    "# Usage:\n",
+    "#\n",
+    "# @require_appkey\n",
+    "# def routefunction():\n",
+    "\n",
+    "YOUR_API_KEY = \"4191d34b28ed4885a1ea0b141e0794ef\"\n",
+    "def require_appkey(view_function):\n",
+    "    @wraps(view_function)\n",
+    "    # the new, post-decoration function. Note *args and **kwargs here.\n",
+    "    def decorated_function(*args, **kwargs):\n",
+    "        key = None\n",
+    "        keytype = None\n",
+    "\n",
+    "        # Ensure Authorization header is present, and the content is 2 words 'Bearer [key]'\n",
+    "        # collect both and check it's Bearer before saving the key.\n",
+    "        if 'Authorization' in request.headers:\n",
+    "            payload = request.headers.get('Authorization').split()      \n",
+    "            if len(payload) == 2:\n",
+    "                keyType = payload[0]\n",
+    "                if keyType == 'Bearer':\n",
+    "                    key = payload[1]\n",
+    "\n",
+    "        # If there is no key send 401 (unauthorized), otherwise if the key is wrong\n",
+    "        # send a 403 (forbidden)\n",
+    "        if key:\n",
+    "            if key == YOUR_API_KEY:\n",
+    "                return view_function(*args, **kwargs)\n",
+    "            else:\n",
+    "                try:\n",
+    "                    abort(401)\n",
+    "                except HTTPException as e:\n",
+    "                    return e\n",
+    "        else:\n",
+    "            try:\n",
+    "                abort(403)\n",
+    "            except HTTPException as e:\n",
+    "                return e\n",
+    "    return decorated_function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below is the module for the Flask web application.\n",
+    "\n",
+    "Note that we include the Azure Application Insights and Api Security files below. The API Security is applied only to the scoring endpoint and the Azure Application Insights is not currently utilized. "
    ]
   },
   {
@@ -116,12 +249,15 @@
     "import logging\n",
     "import json\n",
     "import driver\n",
+    "from .apisecurity import require_appkey\n",
+    "from .applicationinsights import *\n",
     "\n",
     "app = Flask(__name__)\n",
     "predict_for = driver.get_model_api()\n",
     "\n",
     "\n",
     "@app.route('/score', methods = ['POST'])\n",
+    "@require_appkey\n",
     "def scoreRRS():\n",
     "    \"\"\" Endpoint for scoring\n",
     "    \"\"\"\n",
@@ -439,7 +575,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%dotenv\n",
@@ -459,6 +597,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -540,9 +679,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeployment]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeployment-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -554,7 +693,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Tensorflow/03_TestLocally.ipynb
+++ b/Tensorflow/03_TestLocally.ipynb
@@ -11,7 +11,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -58,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%bash --bg -s \"$image_name\"\n",
@@ -99,7 +103,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "IMAGEURL = \"https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg\""
@@ -108,10 +114,12 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "headers = {'content-type': 'application/json'}"
+    "headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}"
    ]
   },
   {
@@ -207,7 +215,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "images = ('https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg',\n",
@@ -221,7 +231,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "url='http://0.0.0.0:80/score'\n",
@@ -266,7 +278,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image_data = list(map(img_url_to_json, images)) # Retrieve the images and data"
@@ -275,7 +289,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "timer_results = list()\n",
@@ -364,9 +380,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeployment]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeployment-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -378,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Tensorflow/05_TestWebApp.ipynb
+++ b/Tensorflow/05_TestWebApp.ipynb
@@ -11,7 +11,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -25,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "service_json = !kubectl get service azure-dl -o json\n",
@@ -36,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "scoring_url = 'http://{}/score'.format(app_url)\n",
@@ -77,7 +83,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "IMAGEURL = \"https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg\""
@@ -142,7 +150,7 @@
    ],
    "source": [
     "# headers = {'content-type': 'application/json','X-Marathon-App-Id': app_id}\n",
-    "headers = {'content-type': 'application/json'}\n",
+    "headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}\n",
     "jsonimg = img_url_to_json(IMAGEURL)\n",
     "r = requests.post(scoring_url, data=jsonimg, headers=headers) # Run the request twice since the first time takes a \n",
     "                                                              # little longer due to the loading of the model\n",
@@ -168,7 +176,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "images = ('https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/220px-Lynx_lynx_poing.jpg',\n",
@@ -182,7 +192,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "results = [requests.post(scoring_url, data=img_url_to_json(img), headers=headers) for img in images]"
@@ -233,7 +245,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image_data = list(map(img_url_to_json, images)) # Retrieve the images and data"
@@ -242,7 +256,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "timer_results = list()\n",
@@ -304,9 +320,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeployment]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeployment-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -318,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/Tensorflow/06_SpeedTestWebApp.ipynb
+++ b/Tensorflow/06_SpeedTestWebApp.ipynb
@@ -11,7 +11,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import asyncio\n",
@@ -54,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "NUMBER_OF_REQUESTS = 100  # Total number of requests\n",
@@ -71,7 +75,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "service_json = !kubectl get service azure-dl -o json\n",
@@ -82,7 +88,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "scoring_url = 'http://{}/score'.format(app_url)\n",
@@ -147,7 +155,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "url_list = [[scoring_url, jsonimg] for jsonimg in gen_variations_of_one_image(IMAGEURL, NUMBER_OF_REQUESTS)]"
@@ -156,7 +166,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def decode(result):\n",
@@ -166,7 +178,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def fetch(url, session, data, headers):\n",
@@ -180,7 +194,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def bound_fetch(sem, url, session, data, headers):\n",
@@ -192,7 +208,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "async def await_with_progress(coros):\n",
@@ -207,12 +225,13 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "async def run(url_list, num_concurrent=CONCURRENT_REQUESTS):\n",
-    "    headers = {'content-type': 'application/json'}\n",
+    "    headers = {'content-type': 'application/json', 'Authorization' : 'Bearer 4191d34b28ed4885a1ea0b141e0794ef'}\n",
     "    tasks = []\n",
     "    # create instance of Semaphore\n",
     "    sem = asyncio.Semaphore(num_concurrent)\n",
@@ -383,9 +402,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:AKSDeployment]",
+   "display_name": "Python [conda env:py35]",
    "language": "python",
-   "name": "conda-env-AKSDeployment-py"
+   "name": "conda-env-py35-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -397,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add to the creation of the images two new files - applicationinsights.py and apisecurity.py

applicationinsights.py: Commented out but shows how to use Azure Application Insights in the flask app.

apisecurity.py: Provides a basic Bearer token authorization for the score endpoint

Score endpoints updated to require "Authorization" : "Bearer KEY" and all test notebooks updated to use the new auth header with the key provided in apisecurity.py
